### PR TITLE
Changed ExceptionResult and added ToErrorResult method

### DIFF
--- a/src/D20Tek.Minimal.Result.AspNetCore/D20Tek.Minimal.Result.AspNetCore.csproj
+++ b/src/D20Tek.Minimal.Result.AspNetCore/D20Tek.Minimal.Result.AspNetCore.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <Version>0.1.8-prerelease</Version>
+    <Version>0.1.9-prerelease</Version>
     <Title>D20Tek.Minimal.Result.AspNetCore</Title>
     <Company>d20Tek</Company>
     <Description>A straightforward implementation of the Result object pattern. Used to return a monad result that will either be the returned value or a set of errors.

--- a/src/D20Tek.Minimal.Result.Extensions/D20Tek.Minimal.Result.Extensions.csproj
+++ b/src/D20Tek.Minimal.Result.Extensions/D20Tek.Minimal.Result.Extensions.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>D20Tek.Minimal.Result.Extensions</Title>
-    <Version>0.1.8-prerelease</Version>
+    <Version>0.1.9-prerelease</Version>
     <Company>d20Tek</Company>
     <Description>A straightforward implementation of the Result object pattern. Used to return a monad result that will either be the returned value or a set of errors.
 

--- a/src/D20Tek.Minimal.Result/D20Tek.Minimal.Result.csproj
+++ b/src/D20Tek.Minimal.Result/D20Tek.Minimal.Result.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Title>D20Tek.Minimal.Result</Title>
-    <Version>0.1.8-prerelease</Version>
+    <Version>0.1.9-prerelease</Version>
     <Company>d20Tek</Company>
     <Description>A straightforward implementation of the Result object pattern. Used to return a monad result that will either be the returned value or a set of errors.</Description>
     <Copyright>Copyright (c) d20Tek.  All rights reserved.</Copyright>

--- a/src/D20Tek.Minimal.Result/DefaultErrors.cs
+++ b/src/D20Tek.Minimal.Result/DefaultErrors.cs
@@ -6,7 +6,7 @@ namespace D20Tek.Minimal.Result;
 public static class DefaultErrors
 {
     public static Error UnhandledExpection(string message) =>
-        Error.Custom("General.UnhandledException", message, ErrorType.Unexpected);
+        Error.Custom("General.Exception", message, ErrorType.Unexpected);
 
     public static readonly Error Unexpected =
         Error.Unexpected("General.Unexpected", "An unexpected error has occurred.");

--- a/src/D20Tek.Minimal.Result/ResultT.cs
+++ b/src/D20Tek.Minimal.Result/ResultT.cs
@@ -44,6 +44,17 @@ public class Result<TValue> : Result
 
     public static Result<TValue> Success(TValue value) => new Result<TValue>(value);
 
+    public Result<TOther> ToErrorResult<TOther>()
+        where TOther : class
+    {
+        if (IsSuccess)
+        {
+            throw new InvalidOperationException();
+        }
+
+        return ErrorsList;
+    }
+
     public Result<TResult> MapResult<TResult>(Func<TValue, TResult> mapper) =>
         (IsSuccess) ? mapper(Value) : ErrorsList;
 

--- a/tests/D20Tek.Minimal.Result.UnitTests/DefaultErrorsTests.cs
+++ b/tests/D20Tek.Minimal.Result.UnitTests/DefaultErrorsTests.cs
@@ -52,7 +52,7 @@ public sealed class DefaultErrorsTests
     public void FactoryMethod_ShouldCreate_UnhandledExpectionError()
     {
         PerformErrorTest(
-            "General.UnhandledException",
+            "General.Exception",
             "An unhandled exception has occurred.",
             ErrorType.Unexpected,
             DefaultErrors.UnhandledExpection);

--- a/tests/D20Tek.Minimal.Result.UnitTests/ResultTTests.cs
+++ b/tests/D20Tek.Minimal.Result.UnitTests/ResultTTests.cs
@@ -77,7 +77,7 @@ public sealed partial class ResultTTests
     {
         // arrange
         var ex = new ArgumentOutOfRangeException("Test exception.");
-        var expected = Error.Custom("General.UnhandledException", ex.Message, ErrorType.Unexpected);
+        var expected = Error.Custom("General.Exception", ex.Message, ErrorType.Unexpected);
 
         // act
         Result<TestEntity> result = ex;
@@ -144,6 +144,33 @@ public sealed partial class ResultTTests
 
         // assert
         mappedResult.ShouldBeFailure();
+    }
+
+    [TestMethod]
+    public void ToErrorResult_WithFailure()
+    {
+        // arrange
+        Result<int> start = DefaultErrors.Unexpected;
+
+        // act
+        var result = start.ToErrorResult<TestEntity>();
+
+        // assert
+        result.ShouldBeFailure();
+    }
+
+    [TestMethod]
+    [ExcludeFromCodeCoverage]
+    [ExpectedException(typeof(InvalidOperationException))]
+    public void ToErrorResult_WithSuccess_ThrowsException()
+    {
+        // arrange
+        Result<int> start = 42;
+
+        // act
+        _ = start.ToErrorResult<TestEntity>();
+
+        // assert
     }
 
     private TestResponse MapEntity(TestEntity entity) =>

--- a/tests/D20Tek.Minimal.Result.UnitTests/ResultTests.cs
+++ b/tests/D20Tek.Minimal.Result.UnitTests/ResultTests.cs
@@ -69,7 +69,7 @@ public sealed class ResultTests
         // arrange
         var msg = "test exception message.";
         var ex = new ArgumentException(msg);
-        var expectedError = Error.Unexpected("General.UnhandledException", msg);
+        var expectedError = Error.Unexpected("General.Exception", msg);
 
         // act
         Result result = ex;


### PR DESCRIPTION
- Changed code to General.Exception for exception errors rather than UnexpectedException.
- Added ToErrorResult method that converts one result's errors to another type.
